### PR TITLE
feat: google analytics tracking

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -72,6 +72,10 @@ const siteConfig = {
       indexName: "tradetrust",
       algoliaOptions: {},
     },
+    gtag: {
+      trackingID: 'G-7YL3CX08LM',
+      anonymizeIP: true,
+    },
     prism: {
       theme: require("prism-react-renderer/themes/nightOwl"),
     },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -73,8 +73,7 @@ const siteConfig = {
       algoliaOptions: {},
     },
     gtag: {
-      trackingID: 'G-7YL3CX08LM',
-      anonymizeIP: true,
+      trackingID: 'G-7YL3CX08LM'
     },
     prism: {
       theme: require("prism-react-renderer/themes/nightOwl"),


### PR DESCRIPTION
Added in Google Analytics tracking using the @docusaurus/preset-classic, google analytics plugin.
Instructions differ from documentation, due to versioning differences. (ours: 2.0.0-alpha.70, current: 2.0.0-beta.17)
https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-gtag#installation