### PR TITLE
fix: replace govtechsg packages with tradetrust alternatives

### DIFF
--- a/docs/reference/libraries/tt-verify.md
+++ b/docs/reference/libraries/tt-verify.md
@@ -225,7 +225,7 @@ This is where `skip` and `test` methods come into play. We will use the `test` m
 ```ts
 // index.ts
 import { verificationBuilder, openAttestationVerifiers, Verifier, isValid } from "@tradetrust-tt/tt-verify";
-import { getData } from "@govtechsg/open-attestation";
+import { getData } from "@tradetrust-tt/tradetrust";
 import * as document from "./document.json";
 
 const customVerifier: Verifier<any> = {
@@ -254,7 +254,7 @@ Once we have decided `when` the verification method run, it's time to write the 
 ```ts
 // index.ts
 import { verificationBuilder, openAttestationVerifiers, Verifier, isValid } from "@tradetrust-tt/tt-verify";
-import { getData } from "@govtechsg/open-attestation";
+import { getData } from "@tradetrust-tt/tradetrust";
 import * as document from "./document.json";
 
 const customVerifier: Verifier<any> = {
@@ -298,7 +298,7 @@ Extending from what have been mentioned in [Custom Verification](#custom-verific
 ```ts
 // index.ts
 import { verificationBuilder, openAttestationVerifiers, Verifier, isValid } from "@tradetrust-tt/tt-verify";
-import { getData } from "@govtechsg/open-attestation";
+import { getData } from "@tradetrust-tt/tradetrust";
 import document from "./document.json";
 
 // our custom verifier will be valid only if the document version is not https://schema.openattestation.com/2.0/schema.json

--- a/docs/topics/advanced/aws-kms/did-sign-demo.md
+++ b/docs/topics/advanced/aws-kms/did-sign-demo.md
@@ -21,7 +21,7 @@ const {
   wrapDocument,
   signDocument,
   SUPPORTED_SIGNING_ALGORITHM,
-} = require("@govtechsg/open-attestation");
+} = require("@tradetrust-tt/tradetrust");
 
 const { AwsKmsSigner } = require("ethers-aws-kms-signer");
 ```
@@ -95,7 +95,7 @@ const {
   wrapDocument,
   signDocument,
   SUPPORTED_SIGNING_ALGORITHM,
-} = require("@govtechsg/open-attestation");
+} = require("@tradetrust-tt/tradetrust");
 
 const { AwsKmsSigner } = require("ethers-aws-kms-signer");
 
@@ -164,7 +164,7 @@ didSignDemo();
     "dotenv": "^9.0.2"
   },
   "dependencies": {
-    "@govtechsg/open-attestation": "^5.3.0",
+    "@tradetrust-tt/tradetrust": "^6.9.4",
     "ethers-aws-kms-signer": "^1.1.0"
   }
 }

--- a/docs/topics/verifying-documents/issuance-status.md
+++ b/docs/topics/verifying-documents/issuance-status.md
@@ -61,7 +61,7 @@ A TradeTrust verifier:
 
   ```js
   import { providers } from "ethers";
-  import { DocumentStoreFactory } from "@govtechsg/document-store";
+  import { DocumentStoreFactory } from "@tradetrust-tt/document-store";
 
   try {
     const documentStore = "0xabc..."; // your document store address
@@ -94,7 +94,7 @@ A TradeTrust verifier:
 
   ```js
   import { providers } from "ethers";
-  import { DocumentStoreFactory } from "@govtechsg/document-store";
+  import { DocumentStoreFactory } from "@tradetrust-tt/document-store";
 
   try {
     const documentStore = "0xabc..."; // your document store address

--- a/docs/tutorial/decentralised-renderer/decentralised-renderer.md
+++ b/docs/tutorial/decentralised-renderer/decentralised-renderer.md
@@ -77,7 +77,7 @@ Now that we have set up the development environment, we can start writing our do
 To update the raw document data and the corresponding data type, you will need to create the new folder for the template and data definition file in `src/templates/coc/sample.ts`:
 
 ```typescript jsx
-import { v2 } from "@govtechsg/open-attestation";
+import { v2 } from "@tradetrust-tt/tradetrust";
 
 export interface CocTemplateCertificate extends v2.OpenAttestationDocument {
   name: string;
@@ -155,7 +155,7 @@ The first step consist of creating a file `src/templates/coc/template.tsx` with 
 
 ```jsx harmony
 import React, { FunctionComponent } from "react";
-import { TemplateProps } from "@govtechsg/decentralized-renderer-react-components";
+import { TemplateProps } from "@tradetrust-tt/decentralized-renderer-react-components";
 import { css } from "@emotion/core";
 import { CocTemplateCertificate } from "./sample";
 
@@ -241,7 +241,7 @@ To register a new template, simply add it as a key to the `registry` constant. T
 Replace `src/templates/index.tsx` with the following code to add the new `COC` template:
 
 ```js
-import { TemplateRegistry } from "@govtechsg/decentralized-renderer-react-components";
+import { TemplateRegistry } from "@tradetrust-tt/decentralized-renderer-react-components";
 import { templates } from "./coc";
 
 export const registry: TemplateRegistry<any> = {

--- a/docs/tutorial/transferable-records/issuing-document/issuing-document-code.mdx
+++ b/docs/tutorial/transferable-records/issuing-document/issuing-document-code.mdx
@@ -15,7 +15,7 @@ In this final step, we will mint the transferable record and initialize the firs
 ## Installation
 
 ```bash
-npm install --save @govtechsg/token-registry
+npm install --save @tradetrust-tt/token-registry
 ```
 
 ## Usage
@@ -27,7 +27,7 @@ Refer to the [pre-requisite](/docs/tutorial/transferable-records/token-registry/
 ### Connect to existing token registry
 
 ```ts
-import { TradeTrustToken__factory } from "@govtechsg/token-registry/contracts";
+import { TradeTrustToken__factory } from "@tradetrust-tt/token-registry/contracts";
 
 const privateKey = "";
 const tokenRegistryAddress = "0x7Ae2aE35f66ACE6671CB2bfb985011b0a2d9cf72";
@@ -44,7 +44,7 @@ const connectedRegistry = TradeTrustToken__factory.connect(tokenRegistryAddress,
 In the example, we will use `0x6FFeD6E6591b808130a9b248fEA32101b5220eca` wallet address as owner and holder. You will need to replace this value with a wallet address you control to be able to perform different actions on the transferable records later.
 
 ```ts
-import { TradeTrustToken__factory } from "@govtechsg/token-registry/contracts";
+import { TradeTrustToken__factory } from "@tradetrust-tt/token-registry/contracts";
 
 const privateKey = "";
 const tokenRegistryAddress = "0x7Ae2aE35f66ACE6671CB2bfb985011b0a2d9cf72";

--- a/docs/tutorial/transferable-records/token-registry/token-registry-code.mdx
+++ b/docs/tutorial/transferable-records/token-registry/token-registry-code.mdx
@@ -20,7 +20,7 @@ In this guide, we will deploy a token registry smart contract on the Ethereum bl
 ## Installation
 
 ```sh
-npm install --save @govtechsg/token-registry
+npm install --save @tradetrust-tt/token-registry
 ```
 
 ## Usage
@@ -32,9 +32,9 @@ Refer to the [pre-requisite](/docs/tutorial/prerequisites#understanding-provider
 ### Deploy a token registry
 
 ```ts
-import { TDocDeployer__factory } from "@govtechsg/token-registry/contracts";
-import { constants as TokenRegistryConstants, utils as TokenRegistryUtils } from "@govtechsg/token-registry";
-import { DeploymentEvent } from "@govtechsg/token-registry/dist/contracts/contracts/utils/TDocDeployer";
+import { TDocDeployer__factory } from "@tradetrust-tt/token-registry/contracts";
+import { constants as TokenRegistryConstants, utils as TokenRegistryUtils } from "@tradetrust-tt/token-registry";
+import { DeploymentEvent } from "@tradetrust-tt/token-registry/dist/contracts/contracts/utils/TDocDeployer";
 
 const unconnectedWallet = new Wallet("privateKey");
 const provider = ethers.getDefaultProvider("sepolia");
@@ -250,7 +250,7 @@ console.log(`Transaction: ${JSON.stringify(receipt)}`);
 ### Connecting to token registry
 
 ```ts
-import { TradeTrustToken__factory } from "@govtechsg/token-registry/contracts";
+import { TradeTrustToken__factory } from "@tradetrust-tt/token-registry/contracts";
 
 const privateKey = "";
 const tokenRegistryAddress = "0x7Ae2aE35f66ACE6671CB2bfb985011b0a2d9cf72";

--- a/docs/tutorial/transferable-records/wrapping-document/wrapping-document-code.mdx
+++ b/docs/tutorial/transferable-records/wrapping-document/wrapping-document-code.mdx
@@ -24,7 +24,7 @@ A `merkleRoot`, a 64 character long string prepended with `0x` will be generated
 ## Installation
 
 ```bash
-npm i --save @govtechsg/open-attestation
+npm i --save @tradetrust-tt/tradetrust
 ```
 
 ---
@@ -36,7 +36,7 @@ npm i --save @govtechsg/open-attestation
 `wrapDocument` takes in a documents and returns the wrapped document. Upon validating the document against it's schema, the document hash will be computed, to be placed onto the `signature` section of the wrapped document. The `signature` is to be used for integrity verification on the later stage of the tutorial.
 
 ```js
-import { wrapDocument } from "@govtechsg/open-attestation";
+import { wrapDocument } from "@tradetrust-tt/tradetrust";
 const document = {
   id: "SERIAL_NUMBER_123",
   $template: {

--- a/docs/tutorial/verifiable-documents/advanced/document-store/deploying-document-store/document-store-code.mdx
+++ b/docs/tutorial/verifiable-documents/advanced/document-store/deploying-document-store/document-store-code.mdx
@@ -14,7 +14,7 @@ import Flow from "../flow.mdx";
 ## Installation
 
 ```sh
-npm install --save @govtechsg/document-store
+npm install --save @tradetrust-tt/document-store
 ```
 
 ---
@@ -28,7 +28,7 @@ Refer to the [pre-requisite](/docs/tutorial/prerequisites#understanding-provider
 ### Deploy new document store
 
 ```ts
-import { DocumentStoreFactory } from "@govtechsg/document-store";
+import { DocumentStoreFactory } from "@tradetrust-tt/document-store";
 import { TransactionReceipt } from "@ethersproject/abstract-provider";
 import { Wallet, ethers } from "ethers";
 
@@ -47,7 +47,7 @@ console.log(documentStoreAddress); // 0x63A223E025256790E88778a01f480eBA77731D04
 ### Connect to existing document store
 
 ```ts
-import { DocumentStoreFactory } from "@govtechsg/document-store";
+import { DocumentStoreFactory } from "@tradetrust-tt/document-store";
 import { TransactionReceipt } from "@ethersproject/abstract-provider";
 import { Wallet, ethers } from "ethers";
 

--- a/docs/tutorial/verifiable-documents/advanced/document-store/issuing-document/issuing-document-code.mdx
+++ b/docs/tutorial/verifiable-documents/advanced/document-store/issuing-document/issuing-document-code.mdx
@@ -14,7 +14,7 @@ import Flow from "../flow.mdx";
 ## Installation
 
 ```sh
-npm install --save @govtechsg/document-store
+npm install --save @tradetrust-tt/document-store
 ```
 
 ---
@@ -28,7 +28,7 @@ Refer to the [pre-requisite](/docs/tutorial/verifiable-documents/advanced/docume
 ### Connect to existing document store
 
 ```ts
-import { DocumentStoreFactory } from "@govtechsg/document-store";
+import { DocumentStoreFactory } from "@tradetrust-tt/document-store";
 import { TransactionReceipt } from "@ethersproject/abstract-provider";
 import { Wallet, ethers } from "ethers";
 

--- a/docs/tutorial/verifiable-documents/advanced/document-store/revoking-document/revoking-document-code.mdx
+++ b/docs/tutorial/verifiable-documents/advanced/document-store/revoking-document/revoking-document-code.mdx
@@ -13,7 +13,7 @@ import Flow from "../flow.mdx";
 ## Installation
 
 ```sh
-npm i @govtechsg/document-store
+npm i @tradetrust-tt/document-store
 ```
 
 ---
@@ -27,7 +27,7 @@ Refer to the [pre-requisite](/docs/tutorial/verifiable-documents/advanced/docume
 ### Connect to existing document store
 
 ```ts
-import { DocumentStoreFactory } from "@govtechsg/document-store";
+import { DocumentStoreFactory } from "@tradetrust-tt/document-store";
 import { TransactionReceipt } from "@ethersproject/abstract-provider";
 import { Wallet, ethers } from "ethers";
 

--- a/docs/tutorial/verifiable-documents/advanced/document-store/wrapping-document/wrapping-document-code.mdx
+++ b/docs/tutorial/verifiable-documents/advanced/document-store/wrapping-document/wrapping-document-code.mdx
@@ -24,7 +24,7 @@ A `merkleRoot`, a 64 character long string prepended with `0x` will be generated
 ## Installation
 
 ```bash
-npm i --save @govtechsg/open-attestation
+npm i --save @tradetrust-tt/tradetrust
 ```
 
 ---
@@ -36,7 +36,7 @@ npm i --save @govtechsg/open-attestation
 `wrapDocument` takes in a documents and returns the wrapped document. Upon validating the document against it's schema, the document hash will be computed, to be placed onto the `signature` section of the wrapped document. The `signature` is to be used for integrity verification on the later stage of the tutorial.
 
 ```js
-import { wrapDocument } from "@govtechsg/open-attestation";
+import { wrapDocument } from "@tradetrust-tt/tradetrust";
 const document = {
   "$template": {
     "name": "main",
@@ -102,7 +102,7 @@ In the scenerio of `wrapDocument`, `signature.merkleRoot` will be the same as `s
 `wrapDocuments` takes in an array of documents and returns the wrapped batch. Each document must be valid regarding the version of the schema used (see below) It computes the Merkle root of the batch and appends it to each document. This Merkle root can be published on the blockchain and queried against to prove the provenance of the document issued this way. Alternatively, the Merkle root may be signed by the document issuer's private key, which may be cryptographically verified using the issuer's public key or Ethereum account.
 
 ```js
-import { wrapDocuments } from "@govtechsg/open-attestation";
+import { wrapDocuments } from "@tradetrust-tt/tradetrust";
   const document = {
   "recipient": {
     "name": "John Doe"

--- a/docs/tutorial/verifiable-documents/signing-document/signing-document-code.mdx
+++ b/docs/tutorial/verifiable-documents/signing-document/signing-document-code.mdx
@@ -16,7 +16,7 @@ After wrapping the documents and obtaining a merkle root, the documents are read
 ## Installation
 
 ```bash
-npm i @govtechsg/open-attestation
+npm i @tradetrust-tt/tradetrust
 ```
 
 ---

--- a/docs/tutorial/verifiable-documents/wrapping-document/wrapping-document-code.mdx
+++ b/docs/tutorial/verifiable-documents/wrapping-document/wrapping-document-code.mdx
@@ -24,7 +24,7 @@ A `merkleRoot`, a 64 character long string prepended with `0x` will be generated
 ## Installation
 
 ```bash
-npm i --save @govtechsg/open-attestation
+npm i --save @tradetrust-tt/tradetrust
 ```
 
 ---
@@ -36,7 +36,7 @@ npm i --save @govtechsg/open-attestation
 `wrapDocument` takes in a documents and returns the wrapped document. Upon validating the document against it's schema, the document hash will be computed, to be placed onto the `signature` section of the wrapped document. The `signature` is to be used for integrity verification on the later stage of the tutorial.
 
 ```js
-import { wrapDocument } from "@govtechsg/open-attestation";
+import { wrapDocument } from "@tradetrust-tt/tradetrust";
 const document = {
   "recipient": {
     "name": "John Doe"
@@ -106,7 +106,7 @@ In the scenerio of `wrapDocument`, `signature.merkleRoot` will be the same as `s
 `wrapDocuments` takes in an array of documents and returns the wrapped batch. Each document must be valid regarding the version of the schema used (see below) It computes the Merkle root of the batch and appends it to each document. This Merkle root can be published on the blockchain and queried against to prove the provenance of the document issued this way. Alternatively, the Merkle root may be signed by the document issuer's private key, which may be cryptographically verified using the issuer's public key or Ethereum account.
 
 ```js
-import { wrapDocuments } from "@govtechsg/open-attestation";
+import { wrapDocuments } from "@tradetrust-tt/tradetrust";
   const document = {
   "recipient": {
     "name": "John Doe"


### PR DESCRIPTION
**Description**

In user documentation, govtechsg packages are replaced with alternative tradetrust packages. So, when the user follows the documentation, they install and use tradetrust packages.