### PR TITLE
fix: token registry v5 missing deployment example

### DIFF
--- a/docs/how-tos/bitstring.md
+++ b/docs/how-tos/bitstring.md
@@ -19,6 +19,7 @@ The **Bitstring Status List** efficiently tracks the revocation/suspension state
 This approach enables verifiers to determine the status of a credential without altering the original VC.
 
 ## Installation
+
 To install the package, use:
 
 ```bash
@@ -34,8 +35,8 @@ import {
   createCredentialStatusPayload,
   CredentialStatusPurpose,
   StatusList,
-} from '@trustvc/w3c-credential-status';
-import { signCredential } from '@trustvc/w3c-vc';
+} from "@trustvc/trustvc/w3c/credential-status";
+import { signCredential } from "@trustvc/trustvc/w3c/vc";
 ```
 
 ### 2. Set Up Hosting URL and Status List
@@ -43,7 +44,7 @@ import { signCredential } from '@trustvc/w3c-vc';
 Pick a hosting URL for the status list:
 
 ```ts
-const hostingUrl = 'https://example.com/credentials/status/3';
+const hostingUrl = "https://example.com/credentials/status/3";
 ```
 
 Initialize a new StatusList:
@@ -57,7 +58,7 @@ const credentialStatus = new StatusList({ length: 131072 }); // Default: 131,072
 Choose between `revocation` or `suspension`:
 
 ```ts
-const purpose: CredentialStatusPurpose = 'revocation';
+const purpose: CredentialStatusPurpose = "revocation";
 ```
 
 ### 4. Update the Status of an Index
@@ -88,22 +89,22 @@ const options = {
   id: hostingUrl,
   credentialSubject: {
     id: `${hostingUrl}#list`,
-    type: 'StatusList2021',
+    type: "StatusList2021",
     statusPurpose: purpose,
     encodedList,
   },
 };
 
 const keyPair = {
-  id: 'did:web:example.com#keys-1',
-  type: 'Bls12381G2Key2020',
-  controller: 'did:web:example.com',
-  privateKeyBase58: '<privateKeyBase58>',
-  publicKeyBase58: '<publicKeyBase58>',
+  id: "did:web:example.com#keys-1",
+  type: "Bls12381G2Key2020",
+  controller: "did:web:example.com",
+  privateKeyBase58: "<privateKeyBase58>",
+  publicKeyBase58: "<publicKeyBase58>",
 };
 
 const credentialStatusVC = await createCredentialStatusPayload(options, keyPair);
-console.log('Credential Status VC:', credentialStatusVC);
+console.log("Credential Status VC:", credentialStatusVC);
 ```
 
 Sign the Credential Status VC:
@@ -111,7 +112,7 @@ Sign the Credential Status VC:
 ```ts
 const { signed, error } = await signCredential(credentialStatusVC, keyPair);
 if (error) throw new Error(error);
-console.log('Signed Credential Status VC:', signed);
+console.log("Signed Credential Status VC:", signed);
 ```
 
 ## Updating the Credential Status List
@@ -123,8 +124,8 @@ import {
   createCredentialStatusPayload,
   fetchCredentialStatusVC,
   StatusList,
-} from '@trustvc/w3c-credential-status';
-import { signCredential } from '@trustvc/w3c-vc';
+} from "@trustvc/trustvc/w3c/credential-status";
+import { signCredential } from "@trustvc/trustvc/w3c/vc";
 ```
 
 ### 2. Fetch the Existing Credential Status VC
@@ -132,13 +133,13 @@ import { signCredential } from '@trustvc/w3c-vc';
 Retrieve the Credential Status VC from the hosting URL:
 
 ```ts
-const hostingUrl = 'https://example.com/credentials/status/3';
+const hostingUrl = "https://example.com/credentials/status/3";
 
 let credentialStatusVC;
 try {
   credentialStatusVC = await fetchCredentialStatusVC(hostingUrl);
 } catch (err) {
-  console.error('Invalid URL:', err);
+  console.error("Invalid URL:", err);
   throw err;
 }
 ```
@@ -172,8 +173,8 @@ const credentialStatusPayload = await createCredentialStatusPayload(
     id: hostingUrl,
     credentialSubject: {
       id: `${hostingUrl}#list`,
-      type: 'StatusList2021',
-      statusPurpose: 'revocation',
+      type: "StatusList2021",
+      statusPurpose: "revocation",
       encodedList,
     },
   },
@@ -182,7 +183,7 @@ const credentialStatusPayload = await createCredentialStatusPayload(
 
 const { signed, error } = await signCredential(credentialStatusPayload, keyPair);
 if (error) throw new Error(error);
-console.log('Updated Credential Status VC:', signed);
+console.log("Updated Credential Status VC:", signed);
 ```
 
 ## Hosting the Credential Status List
@@ -212,7 +213,7 @@ To use the hosted Credential Status List in your Verifiable Credential:
 
 - Replace the example values in the `credentialStatus` object with those relevant to your setup:
 
-    - Update the `id`, `statusListIndex`, and `statusListCredential` fields with the appropriate values based on your hosted Credential Status List and the credential's specific entry.
+  - Update the `id`, `statusListIndex`, and `statusListCredential` fields with the appropriate values based on your hosted Credential Status List and the credential's specific entry.
 
 - Include the `credentialStatus` object in your Verifiable Credential payload before signing.
 

--- a/docs/how-tos/deployment.md
+++ b/docs/how-tos/deployment.md
@@ -100,27 +100,25 @@ This package exposes the [Typechain (Ethers)](https://github.com/dethcrypto/Type
 #### Connect to existing tDocDeployer
 
 ```ts
-import { v5Contracts } from "@trustvc/trustvc";
+import { v5Contracts, v5ContractAddress, v5Utils } from "@trustvc/trustvc";
 import { ethers, Signer } from "ethers";
 
 const rpc = `https://polygon-amoy.infura.io/v3/${INFURA_ID}`; // add your infura ID
-const tDocDeployerAddress = "0x123"; // token registry deployer address
 
 const JsonRpcProvider = ethers.version.startsWith("6.")
   ? (ethers as any).JsonRpcProvider
   : (ethers as any).providers.JsonRpcProvider; // to manage both ether's v5 and v6
 
 const _provider = new JsonRpcProvider(rpc);
+const networkId = await provider.getNetwork();
+
+const tDocDeployerAddress = v5ContractAddress.Deployer[networkId]; // token registry deployer address
 const connectedDeployer = new ethers.Contract(tDocDeployerAddress, v5Contracts.TDocDeployer__factory.abi, _provider);
 
-const encodeInitParams = ({ name, symbol, deployer }: Params) => {
-  return (ethers as any).AbiCoder.defaultAbiCoder().encode(["string", "string", "address"], [name, symbol, deployer]);
-};
-
-const initParam = encodeInitParams({
+const initParam = v5Utils.encodeInitParams({
   name,
   symbol,
-  deployerAddress,
+  deployer: await signer.getAddress(),
 });
 
 const tx = await connectedDeployer.deploy(implAddress, initParam);

--- a/docs/how-tos/issuer/did-web.md
+++ b/docs/how-tos/issuer/did-web.md
@@ -77,13 +77,13 @@ Before you begin, ensure you have Node.js installed on your system.
     1. Install the package:
 
     ```bash
-    npm install @trustvc/w3c-issuer
+    npm install @trustvc/trustvc
     ```
 
     2. Create a script to generate the DID:
 
     ```typescript
-    import { generateKeyPair, issueDID, VerificationType } from "@trustvc/w3c-issuer";
+    import { generateKeyPair, issueDID, VerificationType } from "@trustvc/trustvc/w3c/issuer";
 
     const main = async () => {
       // Generate a key pair
@@ -187,12 +187,12 @@ Before adding new keys:
   <TabItem value="code" label="Using Code">
     1. Install the package:
     ```bash
-    npm install @trustvc/w3c-issuer
+    npm install @trustvc/trustvc
     ```
 
     2. Create a script to generate and add a new key:
     ```typescript
-    import { generateKeyPair, issueDID, VerificationType } from "@trustvc/w3c-issuer";
+    import { generateKeyPair, issueDID, VerificationType } from "@trustvc/trustvc/w3c/issuer";
 
     const addNewKey = async () => {
       // Generate a new key pair
@@ -331,11 +331,11 @@ example.com/
 
 ### Use Cases
 
-| Use Cases | Purpose |
-| --- | --- |
+| Use Cases                | Purpose                                                                                            |
+| ------------------------ | -------------------------------------------------------------------------------------------------- |
 | Organizational Structure | 📂 Different departments having their own DIDs<br/>👥 Team-specific DIDs<br/>📋 Project-based DIDs |
-| User Management | 🔑 Individual user DIDs<br/>👔 Role-based DIDs<br/>⚙️ Service-specific DIDs |
-| Environment Separation | 🛠️ Development DIDs<br/>🧪 Staging DIDs<br/>🚀 Production DIDs |
+| User Management          | 🔑 Individual user DIDs<br/>👔 Role-based DIDs<br/>⚙️ Service-specific DIDs                        |
+| Environment Separation   | 🛠️ Development DIDs<br/>🧪 Staging DIDs<br/>🚀 Production DIDs                                     |
 
 ## Security Considerations
 

--- a/docs/how-tos/open-attestation/transferable-records/token-registry/token-registry-code.mdx
+++ b/docs/how-tos/open-attestation/transferable-records/token-registry/token-registry-code.mdx
@@ -33,10 +33,10 @@ Refer to the [pre-requisite](/docs/how-tos/open-attestation/prerequisites#unders
 ### Deploy a token registry
 
 ```ts
-import { v5Contracts } from "@trustvc/trustvc";
+import { v5Contracts, v5ContractAddress, v5Utils } from "@trustvc/trustvc";
 import { Wallet, ethers } from "ethers";
 
-const { TDocDeployer__factory, TOKEN_REG_CONSTS, DeploymentEvent, encodeInitParams, getEventFromReceipt } = v5Contracts;
+const { TDocDeployer__factory } = v5Contracts;
 // preparing the wallet
 const unconnectedWallet = new Wallet("<your_private_key>");
 const provider = new ethers.providers.JsonRpcProvider("<your_provider_url>");
@@ -44,8 +44,9 @@ const wallet = unconnectedWallet.connect(provider);
 const walletAddress = await wallet.getAddress();
 const chainId = await wallet.getChainId();
 
-const { TokenImplementation, Deployer } = TOKEN_REG_CONSTS.contractAddress;
+const { TokenImplementation, Deployer } = v5ContractAddress;
 const deployerContract = TDocDeployer__factory.connect(Deployer[chainId], wallet);
+const { encodeInitParams, getEventFromReceipt } = v5Utils;
 const initParam = encodeInitParams({
   name: "DemoTokenRegistry",
   symbol: "DTR",

--- a/docs/tutorial/creator.md
+++ b/docs/tutorial/creator.md
@@ -123,10 +123,12 @@ Update `package.json` with the following scripts:
 ### 7. Setup script for single-execution commands
 
 To sign and mint tokens, you'll need:
+
 1. A signing key pair (did:web)
 2. A Token Registry contract (smart contract)
 
 In this example, we'll generate these and store:
+
 - Signing private key and contract address in `.env`
 - Signing public key in `did.json` (served as a public did:web document)
 
@@ -253,8 +255,7 @@ More details [here](/docs/4.x/topics/advanced/additional-network-metamask-guide/
 <summary> Create a `scripts/deployTokenRegistry.ts` file and add the following code:</summary>
 
 ```ts
-import { CHAIN_ID, SUPPORTED_CHAINS, v5ContractAddress, v5Contracts } from "@trustvc/trustvc";
-import { utils as v5Utils } from "@trustvc/trustvc/token-registry-v5";
+import { CHAIN_ID, SUPPORTED_CHAINS, v5ContractAddress, v5Contracts, v5Utils } from "@trustvc/trustvc";
 import { ethers } from "ethers";
 import { writeEnvVariable } from "./utils";
 
@@ -373,6 +374,7 @@ It should only be used for testing purposes.
 :::
 
 To expose your local server using ngrok:
+
 1. Create an account at [ngrok.com](https://ngrok.com/)
 2. Get your authtoken and add it to `.env` as `NGROK_AUTHTOKEN`
 3. Create a static domain and add it to `.env` as `DOMAIN`
@@ -439,8 +441,7 @@ For documents with attachments, you will need to increase the limit of the reque
 <summary>Update `src/index.ts` with the following code:</summary>
 
 ```ts
-import { CHAIN_ID, encrypt, getTokenId, signW3C, SUPPORTED_CHAINS } from "@trustvc/trustvc";
-import { TradeTrustToken__factory } from "@trustvc/trustvc/token-registry-v5/contracts";
+import {v5Contracts, CHAIN_ID, encrypt, getTokenId, signW3C, SUPPORTED_CHAINS } from "@trustvc/trustvc";
 import { CredentialSubjects } from "@trustvc/trustvc/w3c/vc";
 import { ethers, Wallet } from "ethers";
 ...
@@ -551,7 +552,7 @@ app.post("/create/:documentId", async (req: Request, res: Response, next: NextFu
     const wallet = unconnectedWallet.connect(provider);
     const tokenRegistry = new ethers.Contract(
       SYSTEM_TOKEN_REGISTRY_ADDRESS,
-      TradeTrustToken__factory.abi,
+      v5Contracts.TradeTrustToken__factory.abi,
       wallet
     );
 
@@ -625,6 +626,7 @@ output:
 ## Conclusion
 
 In this tutorial, You've learned how to:
+
 1. Create a did:web identifier
 2. Deploy a Token Registry contract
 3. Create transferable documents using the Token Registry


### PR DESCRIPTION
Updated deployment example for token registry v5 
Fixed imports which are no more valid

[Jira Ticket](https://afa-cdi.atlassian.net/browse/TT-660?atlOrigin=eyJpIjoiYzMzOTFkNTkyYTM1NDI5ZTkwOTMyM2RjNTJjZmI3NWYiLCJwIjoiaiJ9)