### PR TITLE
docs: Remove DID verification references

### DIFF
--- a/docs/how-tos/issuer/dns-did.md
+++ b/docs/how-tos/issuer/dns-did.md
@@ -1,40 +1,40 @@
 ---
 id: dns-did
-title: Issuer method DID / DNS-DID
-sidebar_label: Issuer method DID / DNS-DID
+title: Issuer method DNS-DID
+sidebar_label: Issuer method DNS-DID
 ---
 
 :::important
 This segment is retained for legacy support for Open Attestation Document. For more information, please refer to v4 docs.
 :::
 
-| Requirement                       | DNS-TXT | DNS-DID | DID     |
-| --------------------------------- | ------- | ------- | ------- |
-| Domain name needed?               | &check; | &check; | &cross; |
-| Smart contract deployment needed? | &check; | &cross; | &cross; |
-| Identifiable issuer?              | &check; | &check; | &cross; |
+| Requirement                       | DNS-TXT | DNS-DID |
+| --------------------------------- | ------- | ------- |
+| Domain name needed?               | &check; | &check; |
+| Smart contract deployment needed? | &check; | &cross; |
+| Identifiable issuer?              | &check; | &check; |
 
 > smart contract deployment is the deployment of either document store smart contract or token registry smart contracts.
 
-Alternatively to DNS-TXT method, as an issuer one can use either `DID` or `DNS-DID` issuer method to verify that they indeed sign over the TradeTrust document.
+Alternatively to DNS-TXT method, as an issuer one can use `DNS-DID` issuer method to verify that they indeed sign over the TradeTrust document.
 
 :::note
 
 Please take note of the document types that supports this method of identifying the issuer.
 
-| Document type        | Support DID / DNS-DID |
-| -------------------- | --------------------- |
-| Verifiable Document  | &check;               |
-| Transferable Records | &cross;               |
+| Document type        | Supports DNS-DID |
+| -------------------- | ---------------- |
+| Verifiable Document  | &check;          |
+| Transferable Records | &cross;          |
 
 Not sure which type of document to use?
-Have a better understanding about our different document types: [verifiable documents](/docs/how-tos/open-attestation/verifiable-documents/overview) and [Transferable Records](/docs/introduction/key-components-of-tradetrust/transferability/overview).
+Have a better understanding about our different document types: [Verifiable Documents](/docs/how-tos/open-attestation/verifiable-documents/overview) and [Transferable Records](/docs/introduction/key-components-of-tradetrust/transferability/overview).
 
 :::
 
 ## Rationale
 
-Decentralized identifiers (DIDs) are a new type of identifier that enables verifiable, decentralized digital identity. DID document associated with DIDs contains a verification method. The owner of a DID can use the private key associated and anyone can verify that the owner control the public key. DID is new, 1.0 specification is recommended in July 2022. One advantage is that this allows our document issuance flow to not rely on the need to write on blockchain, eliminating the need for gas fees. You can read more about DID on [wikipedia](https://en.wikipedia.org/wiki/Decentralized_identifier) or deep dive into [w3c specifications](https://www.w3.org/TR/did-core/).
+Decentralized identifiers (DIDs) are a new type of identifier that enables verifiable, decentralized digital identity. DID document associated with DIDs contains a verification method. The owner of a DID can use the private key associated and anyone can verify that the owner control the public key. DID is new, 1.0 specification is recommended in July 2022. One advantage is that this allows our document issuance flow to not rely on the need to write on blockchain, eliminating the need for gas fees. You can read more about DID on [wikipedia](https://en.wikipedia.org/wiki/Decentralized_identifier) or deep dive into [W3C specifications](https://www.w3.org/TR/did-core/).
 
 ## How it works
 
@@ -95,53 +95,20 @@ Example of a DNS-DID signed document:
 }
 ```
 
-## Hands-on Creating a DNS-DID / DID
+## Hands-on Creating a DNS-DID
 
-Before we start creating the DNS-DID / DID, please take note that this method **does not require** any ethers/matic (cryptocurrency) to begin. Which means if you use this method, your verifiable document that you will generate will be free!
+Before we start creating the DNS-DID, please take note that this method **does not require** any ethers/matic (cryptocurrency) to begin. Which means if you use this method, your verifiable document that you will generate will be free!
 Also, please make sure you have completed the prerequisites listed below.
 
 ### Prerequisites
 
-- An etheruem wallet. (DID)
-- Domain name. (DND-DID)
-- Edit access to your domain's DNS records. (DND-DID)
-
-#### Creation of wallet
-
-- Create a [wallet](/docs/how-tos/open-attestation/prerequisites#wallet-creation).
-
-### Creation of DID
-
-With an etheruem wallet address, you can go to `https://dev.uniresolver.io/1.0/identifiers/did:ethr:<YOUR_WALLET_ADDRESS>`. The returned response is an ethr DID document and it will look something like this:
-
-```json
-{
-  "@context": [
-    "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/security/suites/secp256k1recovery-2020/v2",
-    "https://w3id.org/security/v3-unstable"
-  ],
-  "id": "did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d",
-  "verificationMethod": [
-    {
-      "id": "did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d#controller",
-      "type": "EcdsaSecp256k1RecoveryMethod2020",
-      "controller": "did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d",
-      "blockchainAccountId": "eip155:1:0xeB68fae40F796d6605d482773c4a7B266da87A0d"
-    }
-  ],
-  "authentication": ["did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d#controller"],
-  "assertionMethod": ["did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d#controller"]
-}
-```
-
-This method (DID) do not require you to own a domain name. However, please take note that when verifying a document created from this method, the Issuer will reflect the wallet address which can be cryptic to most users. An example will look like this:
-
-![DID ethr](/docs/introduction/did-ethr.png)
+- A wallet ([How to create a wallet](/docs/how-tos/open-attestation/prerequisites#wallet-creation))
+- Domain name
+- Edit access to your domain's DNS records
 
 ### DNS-DID
 
-This method concept is the same as `DNS-TXT` method but instead of using a document store or a token registry we tie our DID to a custom txt record that we created in a domain name we own. Refer to below on how to implement.
+This method concept is the same as `DNS-TXT` method but instead of using a document store or a token registry, we tie our DID to a custom txt record that we created in a domain name we own. Refer to below on how to implement.
 
 ### How to create DNS-DID Record
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -228,6 +228,7 @@
       "version": "5.14.2",
       "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.14.2.tgz",
       "integrity": "sha512-0imdBZDjqxrshw0+eyJUgnkRAbS2W93UQ3BVj8VjN4xQylIMf0fWs72W7MZFdHlH78JJYydevgzqvGMcV0Z1CA==",
+      "peer": true,
       "dependencies": {
         "@algolia/client-common": "5.14.2",
         "@algolia/requester-browser-xhr": "5.14.2",
@@ -453,6 +454,7 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
       "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.0",
@@ -2428,6 +2430,7 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.6.1.tgz",
       "integrity": "sha512-Uq8kyn5DYCDmkUlB9sWChhWghS4lUFNiQU+RXcAXJ3qCVXsBpPsh6RF+npQG1N+j4wAbjydM1iLLJJzp+x3eMQ==",
+      "peer": true,
       "dependencies": {
         "@docusaurus/core": "3.6.1",
         "@docusaurus/logger": "3.6.1",
@@ -2846,6 +2849,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/address": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -3234,6 +3238,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abstract-provider": "^5.7.0",
         "@ethersproject/abstract-signer": "^5.7.0",
@@ -3790,6 +3795,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.0.tgz",
       "integrity": "sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4098,6 +4104,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-8.1.0.tgz",
       "integrity": "sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@svgr/babel-preset": "8.1.0",
@@ -4790,8 +4797,7 @@
     "node_modules/@types/prettier": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "peer": true
+      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA=="
     },
     "node_modules/@types/prismjs": {
       "version": "1.26.5",
@@ -4817,6 +4823,7 @@
       "version": "18.3.12",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -5117,6 +5124,7 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5172,6 +5180,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5214,6 +5223,7 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
       "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
+      "peer": true,
       "dependencies": {
         "@algolia/cache-browser-local-storage": "4.24.0",
         "@algolia/cache-common": "4.24.0",
@@ -5393,7 +5403,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
       "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5486,6 +5495,7 @@
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
       "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -5761,6 +5771,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -6009,6 +6020,7 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
       "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.0.3",
         "@chevrotain/gast": "11.0.3",
@@ -6291,7 +6303,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
       "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "peer": true,
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -6306,7 +6317,6 @@
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
       "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
-      "peer": true,
       "dependencies": {
         "array-back": "^4.0.2",
         "chalk": "^2.4.2",
@@ -6321,7 +6331,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -6333,7 +6342,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6342,7 +6350,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -6356,7 +6363,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -6364,14 +6370,12 @@
     "node_modules/command-line-usage/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "peer": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/command-line-usage/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -6380,7 +6384,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -6389,7 +6392,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "peer": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -6401,7 +6403,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7014,6 +7015,7 @@
       "version": "3.30.3",
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.3.tgz",
       "integrity": "sha512-HncJ9gGJbVtw7YXtIs3+6YAFSSiKsom0amWc33Z7QbylbY2JGMrA0yz4EwrdTScZxnwclXeEZHzO5pxoy0ZE4g==",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -7388,6 +7390,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8279,6 +8282,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@ethersproject/abi": "5.7.0",
         "@ethersproject/abstract-provider": "5.7.0",
@@ -8593,6 +8597,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -8710,7 +8715,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
       "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "peer": true,
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -8844,6 +8848,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -10739,8 +10744,7 @@
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "peer": true
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -13107,7 +13111,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "peer": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -13334,6 +13337,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -13948,6 +13952,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -15031,6 +15036,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -15160,6 +15166,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15226,6 +15233,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-6.0.0.tgz",
       "integrity": "sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       },
@@ -15252,6 +15260,7 @@
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -15419,7 +15428,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
       "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -16577,8 +16585,7 @@
     "node_modules/string-format": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
-      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
-      "peer": true
+      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA=="
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -16877,7 +16884,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
       "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
-      "peer": true,
       "dependencies": {
         "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
@@ -16892,7 +16898,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
       "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -16901,7 +16906,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -17068,6 +17072,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17245,7 +17250,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
       "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
-      "peer": true,
       "dependencies": {
         "chalk": "^4.1.0",
         "command-line-args": "^5.1.1",
@@ -17309,7 +17313,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.3.2.tgz",
       "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
-      "peer": true,
       "dependencies": {
         "@types/prettier": "^2.1.1",
         "debug": "^4.3.1",
@@ -17333,7 +17336,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -17348,7 +17350,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
       "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17368,7 +17369,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -17377,7 +17377,6 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -17392,7 +17391,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -17409,6 +17407,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17421,7 +17420,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -17752,6 +17750,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -17998,6 +17997,7 @@
       "version": "5.96.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.96.1.tgz",
       "integrity": "sha512-l2LlBSvVZGhL4ZrPwyr8+37AunkcYj5qh8o6u2/2rzoPc8gxFJkLj1WxNgooi9pnoc06jh0BjuXnamM4qlujZA==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -18205,6 +18205,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18398,7 +18399,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
       "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
-      "peer": true,
       "dependencies": {
         "reduce-flatten": "^2.0.0",
         "typical": "^5.2.0"
@@ -18411,7 +18411,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
       "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }

--- a/versioned_docs/version-4.x/topics/introduction/issuer-method-dns-did.md
+++ b/versioned_docs/version-4.x/topics/introduction/issuer-method-dns-did.md
@@ -1,36 +1,36 @@
 ---
 id: issuer-method-dns-did
-title: Issuer method DID / DNS-DID
-sidebar_label: Issuer method DID / DNS-DID
+title: Issuer method DNS-DID
+sidebar_label: Issuer method DNS-DID
 ---
 
-| Requirement                       | DNS-TXT | DNS-DID | DID     |
-| --------------------------------- | ------- | ------- | ------- |
-| Domain name needed?               | &check; | &check; | &cross; |
-| Smart contract deployment needed? | &check; | &cross; | &cross; |
-| Identifiable issuer?              | &check; | &check; | &cross; |
+| Requirement                       | DNS-TXT | DNS-DID |
+| --------------------------------- | ------- | ------- |
+| Domain name needed?               | &check; | &check; |
+| Smart contract deployment needed? | &check; | &cross; |
+| Identifiable issuer?              | &check; | &check; |
 
 > smart contract deployment is the deployment of either document store smart contract or token registry smart contracts.
 
-Alternatively to DNS-TXT method, as an issuer one can use either `DID` or `DNS-DID` issuer method to verify that they indeed sign over the TradeTrust document.
+Alternatively to DNS-TXT method, as an issuer one can use `DNS-DID` issuer method to verify that they indeed sign over the TradeTrust document.
 
 :::note
 
 Please take note of the document types that supports this method of identifying the issuer.
 
-| Document type        | Support DID / DNS-DID |
-| -------------------- | --------------------- |
-| Verifiable Document  | &check;               |
-| Transferable Records | &cross;               |
+| Document type        | Support DNS-DID |
+| -------------------- | --------------- |
+| Verifiable Document  | &check;         |
+| Transferable Records | &cross;         |
 
 Not sure which type of document to use?
-Have a better understanding about our different document types: [verifiable documents](/docs/4.x/topics/introduction/verifiable-documents/overview) and [Transferable Records](/docs/4.x/topics/introduction/transferable-records/overview).
+Have a better understanding about our different document types: [Verifiable documents](/docs/4.x/topics/introduction/verifiable-documents/overview) and [Transferable Records](/docs/4.x/topics/introduction/transferable-records/overview).
 
 :::
 
 ## Rationale
 
-Decentralized identifiers (DIDs) are a new type of identifier that enables verifiable, decentralized digital identity. DID document associated with DIDs contains a verification method. The owner of a DID can use the private key associated and anyone can verify that the owner control the public key. DID is new, 1.0 specification is recommended in July 2022. One advantage is that this allows our document issuance flow to not rely on the need to write on blockchain, eliminating the need for gas fees. You can read more about DID on [wikipedia](https://en.wikipedia.org/wiki/Decentralized_identifier) or deep dive into [w3c specifications](https://www.w3.org/TR/did-core/).
+Decentralized identifiers (DIDs) are a new type of identifier that enables verifiable, decentralized digital identity. DID document associated with DIDs contains a verification method. The owner of a DID can use the private key associated and anyone can verify that the owner control the public key. DID is new, 1.0 specification is recommended in July 2022. One advantage is that this allows our document issuance flow to not rely on the need to write on blockchain, eliminating the need for gas fees. You can read more about DID on [wikipedia](https://en.wikipedia.org/wiki/Decentralized_identifier) or deep dive into [W3C specifications](https://www.w3.org/TR/did-core/).
 
 ## How it works
 
@@ -91,49 +91,20 @@ Example of a DNS-DID signed document:
 }
 ```
 
-## Hands-on Creating a DNS-DID / DID
+## Hands-on Creating a DNS-DID
 
-Before we start creating the DNS-DID / DID, please take note that this method **does not require** any ethers/matic (cryptocurrency) to begin. Which means if you use this method, your verifiable document that you will generate will be free!
+Before we start creating the DNS-DID, please take note that this method **does not require** any ethers/matic (cryptocurrency) to begin. Which means if you use this method, your verifiable document that you will generate will be free!
 Also, please make sure you have completed the prerequisites listed below.
 
 ### Prerequisites
 
-- An etheruem wallet. (DID)
-- Domain name. (DND-DID)
-- Edit access to your domain's DNS records. (DND-DID)
-
-#### Creation of wallet
-
-- Create a [wallet](/docs/4.x/tutorial/prerequisites#wallet-creation).
-
-### Creation of DID
-
-With an etheruem wallet address, you can go to `https://dev.uniresolver.io/1.0/identifiers/did:ethr:<YOUR_WALLET_ADDRESS>`. The returned response is an ethr DID document and it will look something like this:
-
-```json
-{
-  "@context": ["https://www.w3.org/ns/did/v1", "https://w3id.org/security/suites/secp256k1recovery-2020/v2"],
-  "id": "did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d",
-  "verificationMethod": [
-    {
-      "id": "did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d#controller",
-      "type": "EcdsaSecp256k1RecoveryMethod2020",
-      "controller": "did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d",
-      "blockchainAccountId": "eip155:1:0xeB68fae40F796d6605d482773c4a7B266da87A0d"
-    }
-  ],
-  "authentication": ["did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d#controller"],
-  "assertionMethod": ["did:ethr:0xeB68fae40F796d6605d482773c4a7B266da87A0d#controller"]
-}
-```
-
-This method (DID) do not require you to own a domain name. However, please take note that when verifying a document created from this method, the Issuer will reflect the wallet address which can be cryptic to most users. An example will look like this:
-
-![DID ethr](/docs/introduction/did-ethr.png)
+- A wallet ([How to create a wallet](/docs/how-tos/open-attestation/prerequisites#wallet-creation))
+- Domain name
+- Edit access to your domain's DNS records
 
 ### DNS-DID
 
-This method concept is the same as `DNS-TXT` method but instead of using a document store or a token registry we tie our DID to a custom txt record that we created in a domain name we own. Refer to below on how to implement.
+This method concept is the same as `DNS-TXT` method but instead of using a document store or a token registry, we tie our DID to a custom txt record that we created in a domain name we own. Refer to below on how to implement.
 
 ### How to create DNS-DID Record
 


### PR DESCRIPTION
Remove DID verification references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured issuer docs to present DNS-DID as the primary method, removing alternative DID-specific content.
  * Simplified requirements and compatibility tables to show DNS-TXT/DNS-DID only, with clarified support indicators.
  * Updated hands-on guide: clearer prerequisites, streamlined DNS-DID creation flow, and refreshed TXT record examples.
  * Fixed terminology, capitalization, punctuation, and other editorial inconsistencies across the document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->