### PR TITLE
fix: restore live cost estimation figures on estimated-cost pages

### DIFF
--- a/docs/introduction/key-components-of-tradetrust/blockchain/estimated-cost-for-transactions.md
+++ b/docs/introduction/key-components-of-tradetrust/blockchain/estimated-cost-for-transactions.md
@@ -12,7 +12,7 @@ You should be aware that the estimated gas required can differ slightly dependin
 :::note
 Note that the following estimation is _not_ a comprehensive list of all the costs involved and should be used as a reference only.
 
-The live gas fees and prices on this page are updated every 15s. Data are retrieved from [BlockNative Gas Estimator](https://www.blocknative.com/gas-estimator) and [CryptoCompare](https://www.cryptocompare.com/).
+The live gas fees and prices on this page are updated every 30s. Gas prices are read directly from public blockchain RPC endpoints and token prices are retrieved from [CoinGecko](https://www.coingecko.com/).
 :::
 
 ### Verifiable Documents

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,7 +15,7 @@
     X-Frame-Options = "DENY"
     
     # Content Security Policy - Comprehensive XSS and injection protection
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://*.algolia.net https://*.algolianet.com https://min-api.cryptocompare.com https://api.blocknative.com https://rpc.xinfin.network https://xdctraderpc.xinfin.network; frame-src https://app.netlify.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://*.algolia.net https://*.algolianet.com https://api.coingecko.com https://ethereum-rpc.publicnode.com https://polygon-bor-rpc.publicnode.com https://rpc.xinfin.network; frame-src https://app.netlify.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests"
     
     # Permissions Policy - Browser feature access control
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=(), payment=(), usb=(), bluetooth=(), magnetometer=(), gyroscope=(), accelerometer=(), autoplay=(), encrypted-media=(), fullscreen=(self), picture-in-picture=()"

--- a/src/components/ContractCost/ContractCostTable/index.tsx
+++ b/src/components/ContractCost/ContractCostTable/index.tsx
@@ -213,7 +213,7 @@ export const PriceTable = (props) => {
         <BoxTag>
           <FiatLabel>{price}</FiatLabel>
         </BoxTag>{" "}
-        for <strong>Ethereum</strong>, MATIC price at USD{" "}
+        for <strong>Ethereum</strong>, POL price at USD{" "}
         <BoxTag>
           <FiatLabel>{maticPrice}</FiatLabel>
         </BoxTag>{" "}

--- a/src/components/ContractCost/hooks/useFetchGasPrice.tsx
+++ b/src/components/ContractCost/hooks/useFetchGasPrice.tsx
@@ -21,11 +21,40 @@ const coinGeckoIds = {
   [Chain.XDC]: "xdce-crowd-sale",
 };
 
+// All hook instances share one batched CoinGecko request (multiple PriceTables
+// mount at once — separate requests per chain trip the free-tier rate limit,
+// whose 429 responses carry no CORS headers and surface as CORS errors).
+const PRICE_CACHE_TTL = 25000;
+const priceUrl = `https://api.coingecko.com/api/v3/simple/price?ids=${Object.values(coinGeckoIds).join(
+  ","
+)}&vs_currencies=usd`;
+let priceCache: { data: any; fetchedAt: number } | null = null;
+let priceInflight: Promise<any> | null = null;
+
+const fetchAllPrices = async () => {
+  if (priceCache && Date.now() - priceCache.fetchedAt < PRICE_CACHE_TTL) {
+    return priceCache.data;
+  }
+  if (!priceInflight) {
+    priceInflight = fetch(priceUrl)
+      .then((req) => {
+        if (!req.ok) throw new Error(`CoinGecko responded ${req.status}`);
+        return req.json();
+      })
+      .then((data) => {
+        priceCache = { data, fetchedAt: Date.now() };
+        return data;
+      })
+      .finally(() => {
+        priceInflight = null;
+      });
+  }
+  return priceInflight;
+};
+
 const fetchPrice = async (chain: Chain) => {
-  const id = coinGeckoIds[chain];
-  const req = await fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${id}&vs_currencies=usd`);
-  const res = await req.json();
-  return res?.[id]?.usd;
+  const res = await fetchAllPrices();
+  return res?.[coinGeckoIds[chain]]?.usd;
 };
 
 const fetchGasPriceInGwei = async (chain: Chain) => {

--- a/src/components/ContractCost/hooks/useFetchGasPrice.tsx
+++ b/src/components/ContractCost/hooks/useFetchGasPrice.tsx
@@ -7,31 +7,29 @@ export enum Chain {
   XDC = "xdc",
 }
 
-const gasApi = {
-  [Chain.Ethereum]: "https://api.blocknative.com/gasprices/blockprices",
-  [Chain.Polygon]: "https://api.blocknative.com/gasprices/blockprices?chainid=137",
+// Public JSON-RPC endpoints (CORS-enabled) used to read the current gas price on-chain.
+const rpcApi = {
+  [Chain.Ethereum]: "https://ethereum-rpc.publicnode.com",
+  [Chain.Polygon]: "https://polygon-bor-rpc.publicnode.com",
   [Chain.XDC]: "https://rpc.xinfin.network",
 };
 
-const parseGasRes = (res: any) => {
-  const estPrice = res.blockPrices[0].estimatedPrices[0];
-  return estPrice.price ? estPrice.price + estPrice.maxPriorityFeePerGas : 0;
-};
-
-const priceApi = {
-  [Chain.Ethereum]: "https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD",
-  [Chain.Polygon]: "https://min-api.cryptocompare.com/data/price?fsym=MATIC&tsyms=USD",
-  [Chain.XDC]: "https://min-api.cryptocompare.com/data/price?fsym=XDC&tsyms=USD",
+// CoinGecko asset ids. Polygon gas is paid in POL (ex-MATIC) since the 2024 migration.
+const coinGeckoIds = {
+  [Chain.Ethereum]: "ethereum",
+  [Chain.Polygon]: "polygon-ecosystem-token",
+  [Chain.XDC]: "xdce-crowd-sale",
 };
 
 const fetchPrice = async (chain: Chain) => {
-  const ethReq = await fetch(priceApi[chain]);
-  const ethRes = await ethReq.json();
-  return ethRes?.USD;
+  const id = coinGeckoIds[chain];
+  const req = await fetch(`https://api.coingecko.com/api/v3/simple/price?ids=${id}&vs_currencies=usd`);
+  const res = await req.json();
+  return res?.[id]?.usd;
 };
 
-const fetchXDCGasPriceInGwei = async () => {
-  const resp = await fetch(gasApi[Chain.XDC], {
+const fetchGasPriceInGwei = async (chain: Chain) => {
+  const resp = await fetch(rpcApi[chain], {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -48,20 +46,13 @@ const fetchXDCGasPriceInGwei = async () => {
   return gasPriceInWei / 1e9;
 };
 
-const fetchGasInGwei = async (chain: Chain) => {
-  if (chain === Chain.XDC) {
-    return await fetchXDCGasPriceInGwei();
-  }
-  const gweiReq = await fetch(gasApi[chain]);
-  const gweiRes = await gweiReq.json();
-  return parseGasRes(gweiRes);
-};
-
 const fetchGasCostData = async (chain: Chain) => {
   try {
     const price = await fetchPrice(chain);
-    const gwei = await fetchGasInGwei(chain);
-    console.log(`Price: ${price}, Gwei: ${gwei} for ${chain}`);
+    const gwei = await fetchGasPriceInGwei(chain);
+    if (!price || !gwei || Number.isNaN(gwei)) {
+      throw new Error(`Incomplete data for ${chain} (price: ${price}, gwei: ${gwei})`);
+    }
     return { price, gwei };
   } catch (e) {
     console.error(`Error: ${e.message}`);

--- a/versioned_docs/version-4.x/topics/introduction/estimated-cost-for-transactions.md
+++ b/versioned_docs/version-4.x/topics/introduction/estimated-cost-for-transactions.md
@@ -12,7 +12,7 @@ You should be aware that the estimated gas required can differ slightly dependin
 :::note
 Note that the following estimation is _not_ a comprehensive list of all the costs involved and should be used as a reference only.
 
-The live gas fees and prices on this page are updated every 15s. Data are retrieved from [BlockNative Gas Estimator](https://www.blocknative.com/gas-estimator) and [CryptoCompare](https://www.cryptocompare.com/).
+The live gas fees and prices on this page are updated every 30s. Gas prices are read directly from public blockchain RPC endpoints and token prices are retrieved from [CoinGecko](https://www.coingecko.com/).
 :::
 
 ### Verifiable Documents


### PR DESCRIPTION
## Problem
The [estimated cost for transactions](https://docs.tradetrust.io/docs/introduction/key-components-of-tradetrust/blockchain/estimated-cost-for-transactions) page (and its 4.x counterpart) shows **Calculating...** forever — no fiat figures ever render.

Both upstream data providers discontinued free, unauthenticated access:
- **CryptoCompare** `min-api` now returns `401 API key required` with no CORS headers, so every browser fetch throws (visible as CORS errors in the console)
- **BlockNative** `gasprices/blockprices` drops the TLS connection outright

The silent `catch` in `useFetchGasPrice` left `price`/`gwei` at `0`, so every cell rendered the eternal `Calculating...` state.

## Fix
- Gas prices: read `eth_gasPrice` directly from public CORS-enabled RPC endpoints — PublicNode for Ethereum and Polygon, reusing the exact pattern already working for XDC via XinFin RPC. One code path for all three chains.
- Token prices: CoinGecko keyless simple-price API (CORS `*`), replacing CryptoCompare.
- Polygon now quotes **POL** (ex-MATIC) per the 2024 token migration — id `polygon-ecosystem-token`, label updated.
- Added a guard so partial API responses can never render `NaN`.
- Updated the data-source attribution note on both the current and `4.x` docs pages (also corrected the stale refresh interval: 30s, not 15s).

`SavingsComparisonsTable` consumes the same hook and is fixed by the same change.

## Testing
- Verified locally (`npm start`) with Playwright on both the current and 4.x pages: live ETH/POL/XDC prices render, all fiat columns calculate, zero console errors.
- All three replacement endpoints verified for CORS (`Access-Control-Allow-Origin: *`) against the `docs.tradetrust.io` origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated transaction cost estimates to use current gas prices from public blockchain networks and token prices from CoinGecko.
  * Live gas fees and token prices now refresh every 30 seconds.
  * Improved handling of incomplete pricing or gas data to prevent displaying invalid estimates.
  * Updated Polygon cost descriptions to use the current “POL” token name.

* **Documentation**
  * Updated transaction cost documentation to reflect the refreshed data sources and 30-second update interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->